### PR TITLE
Prevent recursions from crashing stack

### DIFF
--- a/addon-modules/20WifiScriptEngine/Processor.cs
+++ b/addon-modules/20WifiScriptEngine/Processor.cs
@@ -55,6 +55,7 @@ namespace Diva.Wifi.WifiScript
         private List<object> m_ListOfObjects;
         private int m_Index;
         private static string m_FileName;
+        private int recursions;
 
         public Processor(IWifiScriptFace webApp, IEnvironment env)
             : this(webApp, null, env, null)
@@ -188,8 +189,16 @@ namespace Diva.Wifi.WifiScript
                 }
 
                 // recurse!
+                // TODO: This is bad design and only a bandaid to prevent crashes, avoid recursions!
+                // Page handling needs work to prevent this from occurring in the first place
                 if (!string.IsNullOrEmpty(content))
+                {
+                    recursions++;
+                    if (recursions > 10)
+                        return string.Empty;
+
                     return Process(content);
+                }
             }
 
             return string.Empty;


### PR DESCRIPTION
This is a bandaid more than a true fix, but without preventing recursions from running wild the process will eventually exceed stack and crash. This was reported as being an issue with loading restricted pages while not logged in to wifi. The actual issue is thus elsewhere in the page handling. Nonetheless recursions should be avoided if they have no bail condition that turns true before hitting stack limits. Please fix the page handling for this and perhaps rethink the approach of using recursions for parsing the pages in the first place.